### PR TITLE
Prevented call on synchronised progress handlers

### DIFF
--- a/Classes/Core/OMDeferred.m
+++ b/Classes/Core/OMDeferred.m
@@ -96,9 +96,11 @@
         
     }
     
-    @synchronized (progressHandlers) {
-        for (void (^progressHandler)(float) in progressHandlers) {
-            progressHandler(progress);
+    if (progressHandlers) {
+        @synchronized (progressHandlers) {
+            for (void (^progressHandler)(float) in progressHandlers) {
+                progressHandler(progress);
+            }
         }
     }
 }


### PR DESCRIPTION
Even though the synchronised context will terminate quickly because of the pointer to nil, avoided any interaction with @synchronized if is not necessary.
