### PR TITLE
adding a lazily evaluated promise type

### DIFF
--- a/Classes/Core/OMPromise.h
+++ b/Classes/Core/OMPromise.h
@@ -49,6 +49,8 @@ typedef NS_ENUM(NSInteger, OMPromisesErrorCodes) {
  */
 extern NSString *const OMPromisesErrorDomain;
 
+@class OMDeferred;
+
 /** OMPromise proxies the outcome of a long-running asynchronous operation. It's
  a read-only object which is described essentially by state. The state defines
  how to interpret the values kept in result, error and progress.
@@ -183,6 +185,13 @@ extern NSString *const OMPromisesErrorDomain;
  @see promiseWithTask:
  */
 + (OMPromise *)promiseWithTask:(id (^)())task on:(dispatch_queue_t)queue;
+
+/** Create a promise with a task that is evaluated lazily - not until a listener is attached
+ 
+ @param task The task describing the outcome of the promise.
+ @return A new promise.
+ */
++ (OMPromise*)promiseWithLazyTask:(void (^)(OMDeferred*))task;
 
 /** Create a fulfilled promise.
  

--- a/Classes/Core/OMPromise.m
+++ b/Classes/Core/OMPromise.m
@@ -645,16 +645,19 @@ static dispatch_queue_t globalDefaultQueue = nil;
 
 - (void)dispatchTask
 {
-    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0), ^{
-        @synchronized(self)
+    @synchronized(self)
+    {
+        if (self.task)
         {
-            if (self.task)
+            void (^taskCopy)(OMDeferred*) = self.task;
+            self.task = nil;
+            
+            dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0), ^
             {
-                self.task(self);
-                self.task = nil;
-            }
+                taskCopy(self);
+            });            
         }
-    });    
+    }
 }
 
 - (OMPromise *)fulfilled:(void (^)(id result))fulfilHandler on:(dispatch_queue_t)queue

--- a/OMPromises.podspec
+++ b/OMPromises.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
   s.author       = { 'Oliver Mader' => 'b52@reaktor42.de' }
   s.ios.deployment_target = '5.0'
   s.osx.deployment_target = '10.7'
-  s.source       = { :git => 'https://github.com/b52/OMPromises.git', :tag => s.version.to_s }
+  s.source       = { :git => 'https://github.com/jhollida24/OMPromises.git', :tag => s.version.to_s }
   s.requires_arc = true
 
   s.default_subspec = 'Core'

--- a/Tests/Core/OMPromiseTests.m
+++ b/Tests/Core/OMPromiseTests.m
@@ -1116,6 +1116,37 @@
     XCTAssertEqualWithAccuracy(-tic.timeIntervalSinceNow, 3.5, .15, @"Should be more or less exact in timing");
 }
 
+- (void)testThen_registeringListenersDownstreamEvaluatesLazily
+{
+    __block BOOL eval1 = NO;
+    __block BOOL eval2 = NO;
+    __block BOOL eval3 = NO;
+    
+    OMPromise* promise = [[[OMPromise promiseWithLazyTask:^(OMDeferred *deferredResult)
+    {
+        eval1 = YES;
+        [deferredResult fulfil:nil];
+    }] then:^id(id result)
+    {
+        return [OMPromise promiseWithLazyTask:^(OMDeferred *deferredResult2)
+        {
+            eval2 = YES;
+            [deferredResult2 fulfil:nil];
+        }];
+    }] then:^id(id result)
+    {
+        eval3 = YES;
+        return nil;
+    }];
+    
+    XCTAssertTrue(!eval1 && !eval2 && !eval3, @"none of these should be evaluated yet");
+    
+    [promise fulfilled:^(id result)
+     {
+         XCTAssertTrue(eval1 && eval2 && eval3, @"all 3 must have evaluated");
+     }];
+}
+
 #pragma clang diagnostics pop
 
 @end


### PR DESCRIPTION
Lazily evaluating promises allows me to pass around Promise objects that are only executed if they're actually needed. 

A good example would be a Promise object representing a user's avatar attached to a User object. If User owns a lazily evaluated Promise for its avatar, I can pass that user around everywhere, and won't have to worry that I'm making unnecessary calls for code that doesn't actually need the avatar. If I never encounter any situations where I need to show their avatar, I can avoid ever having to retrieve it.